### PR TITLE
Fix Quick start with Http document error

### DIFF
--- a/docs/quick-start/quick-start-http.md
+++ b/docs/quick-start/quick-start-http.md
@@ -61,7 +61,7 @@ The following log appears when the startup is successful:
 
 The `shenyu-examples-http` project will automatically register interface methods annotated with `@ShenyuSpringMvcClient` in the Apache ShenYu gateway after successful startup.
 
-Open PluginList -> rpc proxy -> divide to see the list of plugin rule configurations:
+Open PluginList -> Proxy -> divide to see the list of plugin rule configurations:
 
 ![](/img/shenyu/quick-start/http/rule-list.png)
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/quick-start/quick-start-http.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/quick-start/quick-start-http.md
@@ -61,7 +61,7 @@ description: Http快速开始
 
 `shenyu-examples-http`项目成功启动之后会自动把加 `@ShenyuSpringMvcClient` 注解的接口方法注册到网关。
 
-打开`插件列表 -> http process -> divide`可以看到插件规则配置列表：
+打开`插件列表 -> Proxy -> divide`可以看到插件规则配置列表：
 
 
 ![](/img/shenyu/quick-start/http/rule-list.png)

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.4.1/quick-start/quick-start-http.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.4.1/quick-start/quick-start-http.md
@@ -61,7 +61,7 @@ description: Http快速开始
 
 `shenyu-examples-http`项目成功启动之后会自动把加 `@ShenyuSpringMvcClient` 注解的接口方法注册到网关。
 
-打开`插件列表 -> http process -> divide`可以看到插件规则配置列表：
+打开`插件列表 -> Proxy -> divide`可以看到插件规则配置列表：
 
 
 ![](/img/shenyu/quick-start/http/rule-list.png)

--- a/versioned_docs/version-2.4.1/quick-start/quick-start-http.md
+++ b/versioned_docs/version-2.4.1/quick-start/quick-start-http.md
@@ -61,7 +61,7 @@ The following log appears when the startup is successful:
 
 The `shenyu-examples-http` project will automatically register interface methods annotated with `@ShenyuSpringMvcClient` in the Apache ShenYu gateway after successful startup.
 
-Open PluginList -> rpc proxy -> divide to see the list of plugin rule configurations:
+Open PluginList -> Proxy -> divide to see the list of plugin rule configurations:
 
 ![](/img/shenyu/quick-start/http/rule-list.png)
 


### PR DESCRIPTION
issue #347
fix Quick start with Http document error edit menu name from rpc proxy or http process to Proxy, fixed v2.4.1 and current quick start document.